### PR TITLE
Add recursive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ export default {
       input: ['src/1.json', 'src/2.json'],
       output: 'dist/config.json',
       verbose: true,
-      watch: true
+      watch: true,
+      recurisve: true,
     })
   ]
 };
 ```
 
 ### Options
+  - recursive (default is `false`). Enable/disable recursive merging
   - verbose (default is `false`). Enable/disable logging
   - watch (default is `false`). Enable/disable watching. If disabled then copy only on start

--- a/index.js
+++ b/index.js
@@ -26,13 +26,15 @@ const createDirIfNotExist = to => {
   });
 };
 
-module.exports = ({ input, output, watch = false, verbose = false }) => {
+module.exports = ({ input, output, watch = false, verbose = false, recursive = false }) => {
   const run = async () => {
     try {
       const files = await Promise.all(input.map(i => readFileAsync(i)));
 
+      const mergeFn = recursive ? merge.recursive : merge;
+
       createDirIfNotExist(output);
-      await writeFileAsync(output, JSON.stringify(merge(...files.map(i => JSON.parse(i))), null, '  '));
+      await writeFileAsync(output, JSON.stringify(mergeFn(...files.map(i => JSON.parse(i))), null, '  '));
 
       if (verbose) {
         console.log('[MERGE][COMPLETE]'.yellow, output);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-merge",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Rollup plugin to merge JSON files",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This pull request adds an option called `recursive` which, when enabled, uses `merge`'s `merge.recursive` function rather than the flat merge it exports by default. Particularly useful for merging nested config objects - at least that's what I'm using it for, now!